### PR TITLE
Use int64 (bigint) data type for date time

### DIFF
--- a/services/auth/prisma/schema.prisma
+++ b/services/auth/prisma/schema.prisma
@@ -14,9 +14,10 @@ model User {
   password       String?
   profileUrl     String
   provider       AuthProvider
-  createdAt      DateTime         @default(now())
+  createdAt      BigInt
   session        Session[]
   userPermission UserPermission[]
+  Organization   Organization[]
 }
 
 enum AuthProvider {
@@ -25,23 +26,26 @@ enum AuthProvider {
 }
 
 model Session {
-  id           String       @id
-  user         User         @relation(fields: [userId], references: [id])
-  userId       String
-  ipAddress    String
-  userAgent    String
-  expiryDate   DateTime
-  createdAt    DateTime     @default(now())
+  id         String   @id
+  user       User     @relation(fields: [userId], references: [id])
+  userId     String
+  ipAddress  String
+  userAgent  String
+  expiryDate BigInt
+  createdAt  BigInt
 }
 
 model Organization {
-  id   Int    @id @default(autoincrement())
-  name String
+  id      Int    @id @default(autoincrement())
+  name    String
+  owner   User   @relation(fields: [ownerId], references: [id])
+  ownerId String
 }
 
 model Workspace {
-  id   Int    @id @default(autoincrement())
-  name String
+  id      Int    @id @default(autoincrement())
+  name    String
+  ownerId String // Can be the User or Organization
 }
 
 model Privilege {
@@ -56,7 +60,7 @@ model Role {
 }
 
 model UserPermission {
-  user         User         @relation(fields: [userId], references: [id])
+  user         User   @relation(fields: [userId], references: [id])
   userId       String
   organization String
   workspace    String

--- a/services/auth/src/services/SessionService.ts
+++ b/services/auth/src/services/SessionService.ts
@@ -66,7 +66,7 @@ export class SessionService {
     const session = await this.getSession(incomingSession);
     if (!session) throw new ExpectedInvalidError(SessionError.Invalid);
 
-    if (new Date() >= session.expiryDate) {
+    if (Date.now() >= session.expiryDate) {
       this.destroySession(session.id);
       throw new ExpectedInvalidError(SessionError.Expired);
     }
@@ -83,11 +83,12 @@ export class SessionService {
 
     const sessionId = crypto.randomUUID();
     const signedSessionId = this.signSessionId(sessionId);
-    const expiryDate = new Date(Date.now() + SessionService.SESSION_MAX_AGE);
+    const createdAt = Date.now();
+    const expiryDate = (createdAt + SessionService.SESSION_MAX_AGE);
     const cookieHeader = cookie.serialize('sid', signedSessionId, {
       path: '/',
       httpOnly: true,
-      maxAge: expiryDate.getTime(),
+      maxAge: expiryDate,
     });
 
     await this.sessionRepository.createSession({
@@ -96,6 +97,7 @@ export class SessionService {
       ipAddress,
       userAgent,
       expiryDate,
+      createdAt,
     });
 
     return cookieHeader;

--- a/services/auth/src/services/UserService.ts
+++ b/services/auth/src/services/UserService.ts
@@ -62,6 +62,7 @@ export class UserService {
       password: hashedPassword,
       profileUrl: avatarUrl,
       provider: 'SELF',
+      createdAt: Date.now(),
     });
   }
 
@@ -75,6 +76,7 @@ export class UserService {
       email: '',
       profileUrl: avatarUrl,
       provider,
+      createdAt: Date.now(),
     };
     return this.userRepository.createUser(user);
   }

--- a/services/grading/prisma/schema.prisma
+++ b/services/grading/prisma/schema.prisma
@@ -27,7 +27,7 @@ model Submission {
   status     SubmissionStatus
   result     String?
   filePath   String
-  uploadedAt DateTime         @default(now())
+  uploadedAt BigInt
 }
 
 model Editor {
@@ -35,7 +35,7 @@ model Editor {
   questionId Int
   language   String
   codePath   String
-  savedAt    DateTime @default(now())
+  savedAt    BigInt
 
   @@id([userId, questionId, language])
 }


### PR DESCRIPTION
## Description
Change database schema (Prisma schema) `DateTime` data type to `BigInt` or `int 64`

### What
Change database schema that matches with gRPC proto

### Why
If we use `DateTime` in the database schema, we will have a type that refers to the DateTime fields generated from Prisma. And have a duplicated one in gRPC api-types package that uses `int64` or `number` in TS type.

### How
We just change the database datetime-related fields to bigint as same as gRPC proto

### Todo list (if applicable)
- [x] Open my computer
- [x] Change proto package
- [x] Change Prisma schema

## Checklist
- [x] Drink juicy beverage when coding ☕️
- [x] Explained the purpose of this PR
- [x] Tested on **Local machine** and verified that there're no visible errors
- [ ] Tested on **Staging server** and verified that there're no visible errors
